### PR TITLE
Make this Flatpak the primary one

### DIFF
--- a/io.github.ec_.Quake3e.OpenArena.appdata.xml
+++ b/io.github.ec_.Quake3e.OpenArena.appdata.xml
@@ -4,7 +4,7 @@
   <id>io.github.ec_.Quake3e.OpenArena</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
-  <developer_name>OA Team and xplshn</developer_name>
+  <developer_name>OA Team, xplshn and contributors</developer_name>
   <provides>
     <id>openarena.desktop</id>
   </provides>
@@ -27,12 +27,10 @@
       Domination.
     </p>
     <p>
-      This version of OpenArena is based on the Quake3e engine by "Ec" on GitHub,
-      we do not take credit for their work or any of the work done by the OpenArena team.
+      This version of OpenArena is based on the Quake3e engine,
+      we do not take credit for the work done by the OpenArena team nor "Eugene", who develops the Quake3e engine.
       This Flatpak was made to be a replacement of the original one released in 2012,
       as it contains bugs and annoyances not present in this engine.
-      The gameplay is 100% compatible and if not, please make
-      an issue in our repo, we'll investigate it.
     </p>
     <p>
       A configuration file is also available, which lets you modify CVARS however you want.

--- a/io.github.ec_.Quake3e.OpenArena.appdata.xml
+++ b/io.github.ec_.Quake3e.OpenArena.appdata.xml
@@ -4,11 +4,11 @@
   <id>io.github.ec_.Quake3e.OpenArena</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
-  <developer_name>xplshn</developer_name>
+  <developer_name>OA Team and xplshn</developer_name>
   <provides>
-    <id>io.github.ec_.Quake3e.OpenArena.desktop</id>
+    <id>openarena.desktop</id>
   </provides>
-  <name>OpenArena (Quake3e)</name>
+  <name>OpenArena</name>
   <summary>Free and open source first-person shooter</summary>
   <launchable type="desktop-id">io.github.ec_.Quake3e.OpenArena.desktop</launchable>
   <description>
@@ -28,11 +28,11 @@
     </p>
     <p>
       This version of OpenArena is based on the Quake3e engine by "Ec" on GitHub,
-      we do not take credit for his work or any of the work done by the OpenArena team.
+      we do not take credit for their work or any of the work done by the OpenArena team.
       This Flatpak was made to be a replacement of the original one released in 2012,
       as it contains bugs and annoyances not present in this engine.
       The gameplay is 100% compatible and if not, please make
-      an issue in our repo, we'll investigate it
+      an issue in our repo, we'll investigate it.
     </p>
     <p>
       A configuration file is also available, which lets you modify CVARS however you want.
@@ -52,7 +52,6 @@
   </screenshots>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-fantasy">moderate</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
     <content_attribute id="violence-bloodshed">mild</content_attribute>
     <content_attribute id="language-profanity">mild</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>

--- a/io.github.ec_.Quake3e.OpenArena.desktop
+++ b/io.github.ec_.Quake3e.OpenArena.desktop
@@ -1,9 +1,10 @@
 [Desktop Entry]
-Name=OpenArena (Quake3e)
+Name=OpenArena
 Comment=First person shooter
 Icon=io.github.ec_.Quake3e.OpenArena
 Exec=openarena-q3e
 Terminal=false
 Type=Application
 Categories=Game;ActionGame;
+Keywords=arena;quake;q3a;
 PrefersNonDefaultGPU=true

--- a/io.github.ec_.Quake3e.OpenArena.yaml
+++ b/io.github.ec_.Quake3e.OpenArena.yaml
@@ -25,7 +25,7 @@ modules:
       # Pull directly from the upstream source
       - type: git
         url: "https://github.com/ec-/Quake3e"
-        commit: "3cadc1586a60ece42dc387e1240e8e656856badc"
+        commit: "ceaa3731cc9d269a3400241c4d34c7257548a650"
        # x-checker-data: # Allow the bot to automatically make PRs for new releases
          # type: git
          # tag-pattern: "^(\\d{4}-\\d{2}-\\d{2})$"


### PR DESCRIPTION
The old Flatpak is now [EOL](https://github.com/flathub/ws.openarena.OpenArena/commit/ccaf587fd47dc9c279dc480edfb174db536f9085) and io.github.ec_.Quake3e.OpenArena is its replacement. Adjust the desktop and AppStream files accordingly.

Closes #53.

@xplshn Please review and merge. Thanks! :-)